### PR TITLE
feat: add `supabase` auth

### DIFF
--- a/main/background.ts
+++ b/main/background.ts
@@ -15,6 +15,8 @@ if (isProd) {
 (async () => {
   await app.whenReady();
 
+  bindHandlers();
+
   const mainWindow = createWindow('main', {
     width: 1000,
     height: 600,
@@ -23,7 +25,6 @@ if (isProd) {
     }
   });
 
-  bindHandlers();
   if (isProd) {
     await mainWindow.loadURL('app://./home');
   } else {

--- a/main/background.ts
+++ b/main/background.ts
@@ -1,40 +1,42 @@
-import path from 'path'
-import { app, ipcMain } from 'electron'
-import serve from 'electron-serve'
-import { createWindow } from './helpers'
+import path from 'path';
+import { app, ipcMain } from 'electron';
+import serve from 'electron-serve';
+import { createWindow } from './helpers';
+import { bindHandlers } from './ipc-handlers';
 
-const isProd = process.env.NODE_ENV === 'production'
+const isProd = process.env.NODE_ENV === 'production';
 
 if (isProd) {
-  serve({ directory: 'app' })
+  serve({ directory: 'app' });
 } else {
-  app.setPath('userData', `${app.getPath('userData')} (development)`)
+  app.setPath('userData', `${app.getPath('userData')} (development)`);
 }
 
-;(async () => {
-  await app.whenReady()
+(async () => {
+  await app.whenReady();
 
   const mainWindow = createWindow('main', {
     width: 1000,
     height: 600,
     webPreferences: {
-      preload: path.join(__dirname, 'preload.js'),
-    },
-  })
+      preload: path.join(__dirname, 'preload.js')
+    }
+  });
 
+  bindHandlers();
   if (isProd) {
-    await mainWindow.loadURL('app://./home')
+    await mainWindow.loadURL('app://./home');
   } else {
-    const port = process.argv[2]
-    await mainWindow.loadURL(`http://localhost:${port}/home`)
-    mainWindow.webContents.openDevTools()
+    const port = process.argv[2];
+    await mainWindow.loadURL(`http://localhost:${port}/home`);
+    mainWindow.webContents.openDevTools();
   }
-})()
+})();
 
 app.on('window-all-closed', () => {
-  app.quit()
-})
+  app.quit();
+});
 
 ipcMain.on('message', async (event, arg) => {
-  event.reply('message', `${arg} World!`)
-})
+  event.reply('message', `${arg} World!`);
+});

--- a/main/helpers/supabase-client.ts
+++ b/main/helpers/supabase-client.ts
@@ -1,0 +1,13 @@
+import { SupabaseClientOptions } from '@supabase/supabase-js';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = 'supabase-url';
+const supabaseAnonKey = 'supabase-anon-key';
+
+const options: SupabaseClientOptions<any> = {
+  db: {
+    schema: 'prod'
+  }
+};
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, options);

--- a/main/ipc-handlers.ts
+++ b/main/ipc-handlers.ts
@@ -1,0 +1,42 @@
+import { app, ipcMain, Notification, session } from 'electron';
+import { supabase } from './helpers/supabase-client';
+
+export const bindHandlers = () => {
+  ipcMain.handle('supabase-auth', async (event, user) => {
+    console.log('Triggered!');
+    const { email, password } = user;
+
+    try {
+      const { data, error } = await supabase.auth.signInWithPassword({
+        email,
+        password
+      });
+
+      if (error) {
+        throw error;
+      }
+
+      new Notification({
+        title: 'My Application',
+        body: '🎉 Successfully logged in'
+      });
+
+      const cookie = {
+        url: app.isPackaged
+          ? 'app://./'
+          : `http://localhost:${process.argv[2]}`,
+        name: 'access_token',
+        httpOnly: true,
+        secure: true,
+        value: data.session.access_token,
+        expirationDate: data.session.expires_at
+      };
+
+      await session.defaultSession.cookies.set(cookie);
+
+      return data.session;
+    } catch (e: any) {
+      throw new Error(e.message || 'Unknown error');
+    }
+  });
+};

--- a/main/ipc-handlers.ts
+++ b/main/ipc-handlers.ts
@@ -3,7 +3,6 @@ import { supabase } from './helpers/supabase-client';
 
 export const bindHandlers = () => {
   ipcMain.handle('supabase-auth', async (event, user) => {
-    console.log('Triggered!');
     const { email, password } = user;
 
     try {

--- a/main/preload.ts
+++ b/main/preload.ts
@@ -1,20 +1,22 @@
-import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron'
+import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron';
 
 const handler = {
   send(channel: string, value: unknown) {
-    ipcRenderer.send(channel, value)
+    ipcRenderer.send(channel, value);
   },
   on(channel: string, callback: (...args: unknown[]) => void) {
     const subscription = (_event: IpcRendererEvent, ...args: unknown[]) =>
-      callback(...args)
-    ipcRenderer.on(channel, subscription)
+      callback(...args);
+    ipcRenderer.on(channel, subscription);
 
     return () => {
-      ipcRenderer.removeListener(channel, subscription)
-    }
+      ipcRenderer.removeListener(channel, subscription);
+    };
   },
-}
+  invoke: (channel: string, ...args: any[]): Promise<any> =>
+    ipcRenderer.invoke(channel, ...args)
+};
 
-contextBridge.exposeInMainWorld('ipc', handler)
+contextBridge.exposeInMainWorld('ipc', handler);
 
-export type IpcHandler = typeof handler
+export type IpcHandler = typeof handler;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "postinstall": "electron-builder install-app-deps"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.39.8",
     "electron-serve": "^1.3.0",
     "electron-store": "^8.1.0"
   },

--- a/renderer/hooks/use-user.tsx
+++ b/renderer/hooks/use-user.tsx
@@ -1,0 +1,50 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState
+} from 'react';
+
+const ctx = createContext<{
+  login: (email: string, password: string) => Promise<void>;
+  loading: boolean;
+}>({
+  login: async () => null,
+  loading: false
+});
+
+export const useUser = () => useContext(ctx);
+
+export const UserProvider: React.FC<{
+  children?: React.ReactNode;
+}> = ({ children }) => {
+  const [loading, setLoading] = useState<boolean>(false);
+  const [profile, setProfile] = useState<any | null>(null);
+
+  const login = useCallback(async (email: string, password: string) => {
+    setLoading(true);
+
+    const payload = {
+      email: email,
+      password: password
+    };
+
+    const response = await window.ipc.invoke('supabase-auth', payload);
+
+    console.log('Supabase response: ', response);
+
+    setLoading(false);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      login,
+      loading,
+      profile
+    }),
+    [login, loading, profile]
+  );
+
+  return <ctx.Provider value={value}>{children}</ctx.Provider>;
+};

--- a/renderer/next-env.d.ts
+++ b/renderer/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/renderer/pages/_app.tsx
+++ b/renderer/pages/_app.tsx
@@ -1,10 +1,15 @@
-import React from 'react'
-import type { AppProps } from 'next/app'
+import React from 'react';
+import type { AppProps } from 'next/app';
 
-import '../styles/globals.css'
+import '../styles/globals.css';
+import { UserProvider } from '../hooks/use-user';
 
 function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+  return (
+    <UserProvider>
+      <Component {...pageProps} />
+    </UserProvider>
+  );
 }
 
-export default MyApp
+export default MyApp;

--- a/renderer/pages/home.tsx
+++ b/renderer/pages/home.tsx
@@ -1,37 +1,82 @@
-import React from 'react'
-import Head from 'next/head'
-import Link from 'next/link'
-import Image from 'next/image'
+import React, { FormEvent, useState } from 'react';
+import Head from 'next/head';
+import { useUser } from '../hooks/use-user';
 
 export default function HomePage() {
+  const { login, loading } = useUser();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
   return (
     <React.Fragment>
       <Head>
         <title>Home - Nextron (with-tailwindcss)</title>
       </Head>
-      <div className="grid grid-col-1 text-2xl w-full text-center">
-        <div>
-          <Image
-            className="ml-auto mr-auto"
-            src="/images/logo.png"
-            alt="Logo image"
-            width="256px"
-            height="256px"
-          />
+      <div className='mx-auto flex h-screen flex-col items-center justify-center px-6 py-8 lg:py-0'>
+        <div className='dark:bg-magic-purple-dark dark:border-magic-purple-background w-full rounded-lg shadow sm:max-w-md md:mt-0 xl:p-0 dark:border'>
+          <div className='space-y-4 p-6 sm:p-8 md:space-y-6'>
+            <div className='flex flex-row items-center'>
+              <h1 className='text-xl font-bold leading-tight tracking-tight text-gray-900 md:text-2xl dark:text-white'>
+                Sign in
+              </h1>
+            </div>
+            <form
+              onSubmit={async (event: FormEvent) => {
+                event.preventDefault();
+
+                // console.log(password);
+
+                await login(email, password);
+              }}
+              className='space-y-4 md:space-y-6'
+              action='#'
+            >
+              <div>
+                <label className='mb-2 block text-sm font-medium text-gray-900 dark:text-white'>
+                  Email
+                </label>
+                <input
+                  value={email}
+                  onChange={(event: any) => {
+                    setEmail(event.target.value);
+                  }}
+                  type='email'
+                  name='email'
+                  id='email'
+                  className='focus:ring-primary-600 focus:border-primary-600 dark:bg-magic-black block w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-gray-900 sm:text-sm dark:border-gray-600 dark:placeholder-gray-400 dark:focus:border-blue-500 dark:focus:ring-blue-500'
+                  placeholder='name@company.com'
+                  required
+                />
+              </div>
+              <div>
+                <label className='mb-2 block text-sm font-medium text-gray-900 dark:text-white'>
+                  Password
+                </label>
+                <input
+                  value={password}
+                  onChange={(event: any) => setPassword(event.target.value)}
+                  type='password'
+                  name='password'
+                  id='password'
+                  placeholder='••••••••'
+                  className='focus:ring-primary-600 focus:border-primary-600 dark:bg-black block w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-gray-900 sm:text-sm dark:border-gray-600 dark:placeholder-gray-400 dark:focus:border-blue-500 dark:focus:ring-blue-500'
+                  required
+                />
+              </div>
+
+              <button
+                type='submit'
+                disabled={loading}
+                className={`bg-blue-500 w-full rounded-lg  px-5 py-2.5 text-center text-sm font-medium text-white focus:outline-none focus:ring-4 focus:ring-blue-300 ${
+                  loading ? 'cursor-not-allowed opacity-50' : ''
+                }`}
+              >
+                {loading ? 'Signing in...' : 'Sign in'}
+              </button>
+            </form>
+          </div>
         </div>
-        <span>⚡ Electron ⚡</span>
-        <span>+</span>
-        <span>Next.js</span>
-        <span>+</span>
-        <span>tailwindcss</span>
-        <span>=</span>
-        <span>💕 </span>
-      </div>
-      <div className="mt-1 w-full flex-wrap flex justify-center">
-        <Link href="/next">
-          <a className="btn-blue">Go to next page</a>
-        </Link>
       </div>
     </React.Fragment>
-  )
+  );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1272,6 +1272,63 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
   integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
 
+"@supabase/functions-js@2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@supabase/functions-js/-/functions-js-2.1.5.tgz#ed1b85f499dfda21d40fe39b86ab923117cb572b"
+  integrity sha512-BNzC5XhCzzCaggJ8s53DP+WeHHGT/NfTsx2wUSSGKR2/ikLFQTBCDzMvGz/PxYMqRko/LwncQtKXGOYp1PkPaw==
+  dependencies:
+    "@supabase/node-fetch" "^2.6.14"
+
+"@supabase/gotrue-js@2.62.2":
+  version "2.62.2"
+  resolved "https://registry.yarnpkg.com/@supabase/gotrue-js/-/gotrue-js-2.62.2.tgz#9f15a451559d71475c953aa0027e1248b0210196"
+  integrity sha512-AP6e6W9rQXFTEJ7sTTNYQrNf0LCcnt1hUW+RIgUK+Uh3jbWvcIST7wAlYyNZiMlS9+PYyymWQ+Ykz/rOYSO0+A==
+  dependencies:
+    "@supabase/node-fetch" "^2.6.14"
+
+"@supabase/node-fetch@2.6.15", "@supabase/node-fetch@^2.6.14":
+  version "2.6.15"
+  resolved "https://registry.yarnpkg.com/@supabase/node-fetch/-/node-fetch-2.6.15.tgz#731271430e276983191930816303c44159e7226c"
+  integrity sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+"@supabase/postgrest-js@1.9.2":
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/@supabase/postgrest-js/-/postgrest-js-1.9.2.tgz#39c839022ce73f4eb5da6fb7724fb6a6392150c7"
+  integrity sha512-I6yHo8CC9cxhOo6DouDMy9uOfW7hjdsnCxZiaJuIVZm1dBGTFiQPgfMa9zXCamEWzNyWRjZvupAUuX+tqcl5Sw==
+  dependencies:
+    "@supabase/node-fetch" "^2.6.14"
+
+"@supabase/realtime-js@2.9.3":
+  version "2.9.3"
+  resolved "https://registry.yarnpkg.com/@supabase/realtime-js/-/realtime-js-2.9.3.tgz#f822401aed70883dca5d538179b11089d6d1b6ed"
+  integrity sha512-lAp50s2n3FhGJFq+wTSXLNIDPw5Y0Wxrgt44eM5nLSA3jZNUUP3Oq2Ccd1CbZdVntPCWLZvJaU//pAd2NE+QnQ==
+  dependencies:
+    "@supabase/node-fetch" "^2.6.14"
+    "@types/phoenix" "^1.5.4"
+    "@types/ws" "^8.5.10"
+    ws "^8.14.2"
+
+"@supabase/storage-js@2.5.5":
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/@supabase/storage-js/-/storage-js-2.5.5.tgz#2958e2a2cec8440e605bb53bd36649288c4dfa01"
+  integrity sha512-OpLoDRjFwClwc2cjTJZG8XviTiQH4Ik8sCiMK5v7et0MDu2QlXjCAW3ljxJB5+z/KazdMOTnySi+hysxWUPu3w==
+  dependencies:
+    "@supabase/node-fetch" "^2.6.14"
+
+"@supabase/supabase-js@^2.39.8":
+  version "2.39.8"
+  resolved "https://registry.yarnpkg.com/@supabase/supabase-js/-/supabase-js-2.39.8.tgz#2d8935438bdd6add82484ecd46edb0cd5b3f8c38"
+  integrity sha512-WpiawHjseIRcCQTZbMJtHUSOepz5+M9qE1jP9BDmg8X7ehALFwgEkiKyHAu59qm/pKP2ryyQXLtu2XZNRbUarw==
+  dependencies:
+    "@supabase/functions-js" "2.1.5"
+    "@supabase/gotrue-js" "2.62.2"
+    "@supabase/node-fetch" "2.6.15"
+    "@supabase/postgrest-js" "1.9.2"
+    "@supabase/realtime-js" "2.9.3"
+    "@supabase/storage-js" "2.5.5"
+
 "@swc/helpers@0.4.11":
   version "0.4.11"
   resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.4.11.tgz#db23a376761b3d31c26502122f349a21b592c8de"
@@ -1372,6 +1429,11 @@
   dependencies:
     undici-types "~5.26.4"
 
+"@types/phoenix@^1.5.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@types/phoenix/-/phoenix-1.6.4.tgz#cceac93a827555473ad38057d1df7d06eef1ed71"
+  integrity sha512-B34A7uot1Cv0XtaHRYDATltAdKx0BvVKNgYNqE4WjtPUa4VQJM7kxeXcVKaH+KS+kCmZ+6w+QaUdcljiheiBJA==
+
 "@types/plist@^3.0.1":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/plist/-/plist-3.0.5.tgz#9a0c49c0f9886c8c8696a7904dd703f6284036e0"
@@ -1410,6 +1472,13 @@
   version "1.10.10"
   resolved "https://registry.yarnpkg.com/@types/verror/-/verror-1.10.10.tgz#d5a4b56abac169bfbc8b23d291363a682e6fa087"
   integrity sha512-l4MM0Jppn18hb9xmM6wwD1uTdShpf9Pn80aXTStnK1C94gtPvJcV2FrDmbOQUAQfJ1cKZHktkQUDwEqaAKXMMg==
+
+"@types/ws@^8.5.10":
+  version "8.5.10"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.10.tgz#4acfb517970853fa6574a3a6886791d04a396787"
+  integrity sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==
+  dependencies:
+    "@types/node" "*"
 
 "@types/yauzl@^2.9.1":
   version "2.10.3"
@@ -4123,6 +4192,11 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
 truncate-utf8-bytes@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz#405923909592d56f78a5818434b0b78489ca5f2b"
@@ -4258,6 +4332,11 @@ watchpack@^2.4.0:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
 webpack-merge@5.10.0:
   version "5.10.0"
   resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-5.10.0.tgz#a3ad5d773241e9c682803abf628d4cd62b8a4177"
@@ -4302,6 +4381,14 @@ webpack@5.90.1:
     watchpack "^2.4.0"
     webpack-sources "^3.2.3"
 
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
+
 which@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
@@ -4336,6 +4423,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+ws@^8.14.2:
+  version "8.16.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.16.0.tgz#d1cd774f36fbc07165066a60e40323eab6446fd4"
+  integrity sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==
 
 xmlbuilder@>=11.0.1, xmlbuilder@^15.1.1:
   version "15.1.1"


### PR DESCRIPTION
### Description

Hey there! My editor made a lot of changes in the files due to linting, so please excuse the mess. The main updates are listed below:

- Added `@supabase/supabase-js` dependency
- Configured `main/helpers/supabase-client.ts`
- Included `bindHandler` and `supabase-auth` channel handler
- Added `invoke` method in `main/preload.ts`
- Created `useUser` hook and provider
- Added a basic login page

Just a heads up, the authentication triggers but doesn't redirect post successful authentication. I'd appreciate your guidance on this. Any resources you have would be great! I'm a beginner at these kinds of stuff 😅

### Goal

My aim was to integrate supabase authentication into the app, starting with that. Initially, I tried utilizing the built-in `pages/api` feature on Next.js, which worked in `dev` but not in the `prod` environment. I noticed your [comment on a Nextron issue](https://github.com/saltyshiomix/nextron/issues/423#issuecomment-1831897410), and following your advice, I shifted all supabase logic to the electron or main process, which surprisingly worked in both `dev` and `prod` builds.

What I'm looking to achieve next is to pass the `cookie` generated by `supabase.auth` back to Next.js or the renderer. I'm not sure if this is necessary or if I'm making incorrect assumptions based on web app practices. Cookies work fine in `dev` with a valid domain like `http://localhost:1234`, but in `prod`, it uses `app://./`, which isn't a valid domain, resulting in an error.

In general, I'd like to understand how you handle supabase auth in your projects, especially those built with nextron. Do you utilize or return cookies at all? Am I on the right track or completely off base? Could you offer some guidance on implementing this feature? Your insights would be greatly appreciated!


### Demo

- `dev` environment demo:

https://github.com/kentbetita/supabase-nextron-auth/assets/153492344/21b750d9-b342-4477-b967-3e3915298c2a

